### PR TITLE
use only default for ember-try

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,6 @@ cache:
 
 env:
   - EMBER_TRY_SCENARIO=default
-  - EMBER_TRY_SCENARIO=ember-release
-  - EMBER_TRY_SCENARIO=ember-beta
-  - EMBER_TRY_SCENARIO=ember-canary
 
 matrix:
   fast_finish: true

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -6,7 +6,7 @@ module.exports = {
       bower: {
         dependencies: { }
       }
-    },
+    }/*,
     {
       name: 'ember-release',
       bower: {
@@ -39,6 +39,6 @@ module.exports = {
           'ember': 'canary'
         }
       }
-    }
+    }*/
   ]
 };


### PR DESCRIPTION
target only ember version addon is written for as consuming apps will also target this version of ember.